### PR TITLE
Add initial package manifest

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "hmpps-book-secure-move-frameworks",
+  "version": "0.1.0",
+  "description": "YAML definitions for the frameworks used by the Book a secure move service",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ministryofjustice/hmpps-book-secure-move-frameworks.git"
+  },
+  "keywords": [
+    "book-a-secure-move",
+    "hmpps",
+    "ministryofjustice"
+  ],
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/ministryofjustice/hmpps-book-secure-move-frameworks/issues"
+  },
+  "homepage": "https://github.com/ministryofjustice/hmpps-book-secure-move-frameworks#readme"
+}


### PR DESCRIPTION
This adds a basic package manifest which will allow the project
to be included in Node.js projects using NPM.