### PR TITLE
Add new key for "flags" in questions

### DIFF
--- a/frameworks/person-escort-record/README.md
+++ b/frameworks/person-escort-record/README.md
@@ -74,8 +74,11 @@ Question files should live in [`questions/`](./questions) and be stored in a fla
   - `followup_comment` - allow for a text box input to be displayed conditionally if a specific value from a question has been selected
     - `label` **(required)** - text displayed on the text box label
     - `validations` - list of [validations](#validations) that need to be applied to this text box
-      - `name` **(required)** - the validation error key
+      - `type` **(required)** - the validation error key
       - `message` - custom text that will be displayed in the form
+  - `flags` - list of flags to conditionally display on summary pages as alerts if this question is answered with this value.
+    - `key` **(required)** - the flag key
+    - `label` **(required)** - text displayed on the flag label
 - `validations` - list of [validations](#validations) that need to be applied to this question
   - `type` **(required)** - the validation error key
   - `message` - custom text that will be displayed in the form

--- a/frameworks/person-escort-record/README.md
+++ b/frameworks/person-escort-record/README.md
@@ -77,7 +77,7 @@ Question files should live in [`questions/`](./questions) and be stored in a fla
       - `type` **(required)** - the validation error key
       - `message` - custom text that will be displayed in the form
   - `flags` - list of flags to conditionally display on summary pages as alerts if this question is answered with this value.
-    - `key` **(required)** - the flag key
+    - `type` **(required)** - the type of the flag to display. Current supported types: `info`, `attention`, `warning`, `alert`
     - `label` **(required)** - text displayed on the flag label
 - `validations` - list of [validations](#validations) that need to be applied to this question
   - `type` **(required)** - the validation error key


### PR DESCRIPTION
To support multiple flags on questions, add a new `flags` option with a specified `key` and `label`, which defines the list of flags to show conditionally when someone answers a question with a particular option