### PR TITLE
Add support to order sections when displayed in a summary

### DIFF
--- a/frameworks/person-escort-record/README.md
+++ b/frameworks/person-escort-record/README.md
@@ -16,6 +16,7 @@ Manifest files should live in [`manifests/`](./manifests) and be stored in a fla
 
 - `name` **(required)** - name of the section. Used for the step heading caption.
 - `steps` - a list of steps for this section. See [steps documentation](#steps) for options.
+- `order` - order in which to display the sections in a summary or a task list
 
 ## Steps
 
@@ -38,8 +39,6 @@ The `type` options allows the use of different types of layout for a step. Not p
 - `interruption-card` - display the step using a blue background, instructions and a "Continue" button instead of "Save and continue". Usually used to define offline process during an online journey.
 
   <img width="40%" src="../../images/interruption-card.png">
-
-
 
 #### Next steps
 

--- a/frameworks/person-escort-record/README.md
+++ b/frameworks/person-escort-record/README.md
@@ -108,9 +108,7 @@ Supported validations:
 
 ## Markdown support
 
-In some places of the framework we support basic [markdown formatting](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet) and some [additional syntax](#custom-markdown-syntax) for custom components.
-
-### Custom markdown syntax
+In some places of the framework we support basic [markdown formatting](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet) and some additional syntax for custom components:
 
 - **[Inset text component](https://design-system.service.gov.uk/components/inset-text/)**
 

--- a/frameworks/person-escort-record/manifests/health-information.yml
+++ b/frameworks/person-escort-record/manifests/health-information.yml
@@ -1,4 +1,5 @@
 name: Health information
+order: 3
 steps:
   -
     name: Health concerns

--- a/frameworks/person-escort-record/manifests/offence-information.yml
+++ b/frameworks/person-escort-record/manifests/offence-information.yml
@@ -1,4 +1,5 @@
 name: Offence details
+order: 2
 steps:
   -
     name: Release status

--- a/frameworks/person-escort-record/manifests/risk-information.yml
+++ b/frameworks/person-escort-record/manifests/risk-information.yml
@@ -1,4 +1,5 @@
 name: Risk information
+order: 1
 steps:
   -
     name: Security


### PR DESCRIPTION
This adds a new option to each manifest to allow the order in which
they are displayed to be controlled from the framework.