### PR TITLE
Add new question type 'add-another'

### DIFF
--- a/frameworks/person-escort-record/README.md
+++ b/frameworks/person-escort-record/README.md
@@ -76,10 +76,14 @@ Question files should live in [`questions/`](./questions) and be stored in a fla
 
 ### Question options
 
-- `type` **(required)** - the type of question input. Current supported types: `radio`, `checkbox`, `text`, `textarea`
+- `type` **(required)** - the type of question input. Current supported types: `radio`, `checkbox`, `text`, `textarea`, `add-another`
 - `question` **(required)** - the full text of the question, usually including a question mark, that should be displayed in forms and summary tables.
+- `list_item_name` - text to display in the "Add another ..." button and item names for questions with type `add-another`
 - `hint` - hint text to display after the question, usually for advice on how to format an answer. Supports [markdown](#markdown-support).
 - `description` - text to display as the summary table row heading for this question. If not supplied, will use `question` value
+- `display` - list of further display styles for question input
+  - `unit` - a one-character string positioned at the beginning of a textbox (currency or number entry textboxes)
+  - `width` - the width of a question input
 - `options` - for question types that require answers to be within a particular set of items. Usually for radios and checkboxes
   - `label` **(required)** - text displayed on the option label
   - `value` - value submitted to the server, defaults to value of `label`
@@ -88,6 +92,9 @@ Question files should live in [`questions/`](./questions) and be stored in a fla
   - `followup_comment` - allow for a text box input to be displayed conditionally if a specific value from a question has been selected
     - `label` **(required)** - text displayed on the text box label
     - `hint` - hint text to display after the label, usually for advice on how to format an answer. Supports [markdown](#markdown-support).
+    - `display` - list of further display styles for question input
+      - `unit` - a one-character string positioned at the beginning of a textbox (currency or number entry textboxes)
+      - `width` - the width of a question input
     - `validations` - list of [validations](#question-validation) that need to be applied to this text box
       - `type` **(required)** - the validation error key
       - `message` - custom text that will be displayed in the form
@@ -97,6 +104,7 @@ Question files should live in [`questions/`](./questions) and be stored in a fla
 - `validations` - list of [validations](#question-validation) that need to be applied to this question
   - `type` **(required)** - the validation error key
   - `message` - custom text that will be displayed in the form
+  - `value` - further data required for some [validation types](#question-validation).
 
 #### Question validation
 
@@ -105,6 +113,9 @@ Validations are defined as an object containing a validation type (`type`) and a
 Supported validations:
 
 - `required` - mark a question as mandatory. For radios or checkboxes it will require at least one option to be selected, for text or textarea questions it will require at least 1 character
+
+- `min_length` - mark the minimum length of items required for a question with a response of type list. This validation requires an extra `value` option which specifies the length as an integer. If not specified defaults to `0`.
+- `max_length` - mark the maximum length of items required for a question with a response of type list. This validation requires an extra `value` option which specifies the length as an integer. If not specified defaults to infinite.
 
 ## Markdown support
 

--- a/frameworks/person-escort-record/manifests/property.yml
+++ b/frameworks/person-escort-record/manifests/property.yml
@@ -1,0 +1,8 @@
+name: Property
+order: 4
+steps:
+  -
+    name: Bags of property
+    slug: bags-of-property
+    questions:
+      - bags-of-property

--- a/frameworks/person-escort-record/questions/bags-of-property.yml
+++ b/frameworks/person-escort-record/questions/bags-of-property.yml
@@ -1,0 +1,7 @@
+type: multiple
+question: Do they have any property?
+description: Bags of property
+list_item_name: Bag
+item_questions:
+  - property-seal-number
+  - property-type

--- a/frameworks/person-escort-record/questions/bags-of-property.yml
+++ b/frameworks/person-escort-record/questions/bags-of-property.yml
@@ -2,6 +2,6 @@ type: multiple
 question: Do they have any property?
 description: Bags of property
 list_item_name: Bag
-item_questions:
+questions:
   - property-seal-number
   - property-type

--- a/frameworks/person-escort-record/questions/property-seal-number.yml
+++ b/frameworks/person-escort-record/questions/property-seal-number.yml
@@ -1,0 +1,6 @@
+type: text
+question: Seal number
+validations:
+  -
+    type: required
+    message: Enter the seal number of the property bag

--- a/frameworks/person-escort-record/questions/property-type.yml
+++ b/frameworks/person-escort-record/questions/property-type.yml
@@ -1,0 +1,7 @@
+type: text
+question: Type of property
+description: Property type
+validations:
+  -
+    type: required
+    message: Enter the property type

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "hmpps-book-secure-move-frameworks",
+  "name": "@hmpps-book-secure-move-frameworks/1.0.0",
   "version": "0.1.0",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "hmpps-book-secure-move-frameworks",
+  "name": "@hmpps-book-secure-move-frameworks/1.0.0",
   "version": "0.1.0",
   "description": "YAML definitions for the frameworks used by the Book a secure move service",
   "repository": {


### PR DESCRIPTION
Add another will require a new option for specifying the `item` name, and validations for the minimum/maximum number of items required.