### PR TITLE
Add new question type 'multiple'

### DIFF
--- a/frameworks/person-escort-record/README.md
+++ b/frameworks/person-escort-record/README.md
@@ -76,10 +76,15 @@ Question files should live in [`questions/`](./questions) and be stored in a fla
 
 ### Question options
 
-- `type` **(required)** - the type of question input. Current supported types: `radio`, `checkbox`, `text`, `textarea`
+- `type` **(required)** - the [type of question](#question-types) input. Current supported types: `radio`, `checkbox`, `text`, `textarea`, `add_multiple_items`
 - `question` **(required)** - the full text of the question, usually including a question mark, that should be displayed in forms and summary tables.
+- `list_item_name` - text to display in the "Add another ..." button and item names, for questions with type [`add_multiple_items`](#question-types). Should be defined as a singular noun.
+- `questions` - list of questions to display relating to a single item, for questions with type [`add_multiple_items`](#question-types)
 - `hint` - hint text to display after the question, usually for advice on how to format an answer. Supports [markdown](#markdown-support).
 - `description` - text to display as the summary table row heading for this question. If not supplied, will use `question` value
+- `display` - list of further display styles for question input
+  - `rows` - the number of rows to display for `textarea` questions
+  - `character_width` - the character width of a question input. Helps to make the input the right size for the content its intended for. Supported values: `20`, `10`, `5`, `4`, `3`, `2`.
 - `options` - for question types that require answers to be within a particular set of items. Usually for radios and checkboxes
   - `label` **(required)** - text displayed on the option label
   - `value` - value submitted to the server, defaults to value of `label`
@@ -87,7 +92,11 @@ Question files should live in [`questions/`](./questions) and be stored in a fla
   - `followup` - list of questions to conditionally display if this question is answered with this value. This will add this question as a dependent question dynamically to any followup questions and include them in the step where this question is defined.
   - `followup_comment` - allow for a text box input to be displayed conditionally if a specific value from a question has been selected
     - `label` **(required)** - text displayed on the text box label
+    - `type` - the [type of question](#question-types) input. Current supported types for followup comments: `text`, `textarea`
     - `hint` - hint text to display after the label, usually for advice on how to format an answer. Supports [markdown](#markdown-support).
+    - `display` - list of further display styles for question input
+      - `rows` - the number of rows to display for `textarea` questions
+      - `character_width` - the character width of a question input. Helps to make the input the right size for the content its intended for. Supported values: `20`, `10`, `5`, `4`, `3`, `2`.
     - `validations` - list of [validations](#question-validation) that need to be applied to this text box
       - `type` **(required)** - the validation error key
       - `message` - custom text that will be displayed in the form
@@ -98,13 +107,23 @@ Question files should live in [`questions/`](./questions) and be stored in a fla
   - `type` **(required)** - the validation error key
   - `message` - custom text that will be displayed in the form
 
+#### Question types
+
+Supported types:
+
+- `text` - renders a text form element.
+- `textarea` - renders a textarea form element.
+- `radio` - renders a radio form element. Radio items are defined under `options`.
+- `checkbox` - renders a checkbox form element. Checkbox items are defined under `options`.
+- `add_multiple_items` - allows a set of questions to be grouped and repeated within a list item. Child questions to display in each group are defined under `questions`. The noun for the item is defined under `list_item_name` in singular form.
+
 #### Question validation
 
 Validations are defined as an object containing a validation type (`type`) and a message (`message`) to display if the response doesn't pass that validation.
 
 Supported validations:
 
-- `required` - mark a question as mandatory. For radios or checkboxes it will require at least one option to be selected, for text or textarea questions it will require at least 1 character
+- `required` - mark a question as mandatory. For radios or checkboxes it will require at least one option to be selected, for text or textarea questions it will require at least 1 character, for add_multiple_items it will require at least 1 item.
 
 ## Markdown support
 

--- a/frameworks/person-escort-record/manifests/property-information.yml
+++ b/frameworks/person-escort-record/manifests/property-information.yml
@@ -1,0 +1,20 @@
+name: Property information
+order: 4
+steps:
+  -
+    name: Property
+    slug: property
+    next_step:
+      -
+        question: property-being-moved
+        value: 'Yes'
+        next_step: property-details
+    questions:
+      - property-being-moved
+      - property-being-retained
+      - property-in-possession
+  -
+    name: Property details
+    slug: property-details
+    questions:
+      - property-bags

--- a/frameworks/person-escort-record/questions/actions-of-self-harm-undertaken.yml
+++ b/frameworks/person-escort-record/questions/actions-of-self-harm-undertaken.yml
@@ -1,5 +1,5 @@
 type: checkbox
-question: What actions have you taken to keep this person safe?
+question: What actions have been taken to keep this person safe?
 hint: Select all that apply
 description: Actions taken to keep person safe
 options:
@@ -68,4 +68,4 @@ options:
 validations:
   -
     type: required
-    message: Select actions taken to keep the person safe
+    message: Select actions that have been taken to keep the person safe

--- a/frameworks/person-escort-record/questions/property-bag-seal-number.yml
+++ b/frameworks/person-escort-record/questions/property-bag-seal-number.yml
@@ -1,0 +1,8 @@
+type: text
+question: Seal number
+display:
+  character_width: 20
+validations:
+  -
+    type: required
+    message: Enter the seal number

--- a/frameworks/person-escort-record/questions/property-bag-type.yml
+++ b/frameworks/person-escort-record/questions/property-bag-type.yml
@@ -1,0 +1,47 @@
+type: checkbox
+question: What type of property is in the bag?
+hint: Select all that apply
+description: Property types
+options:
+  -
+    label: Medication
+    value: Medication
+    followup_comment:
+      label: Give details (optional)
+  -
+    label: UK currency
+    value: UK currency
+    followup_comment:
+      type: text
+      label: Total amount, in pounds
+      hint: For example, 23.99
+      display:
+        character_width: 5
+      validations:
+        -
+          type: required
+          message: Enter the total amount of UK currency
+  -
+    label: Other currency
+    value: Other currency
+    followup_comment:
+      label: Give details of currencies and amounts (optional)
+  -
+    label: Valuables
+    value: Valuables
+    followup_comment:
+      label: Give details (optional)
+  -
+    label: Documentation
+    value: Documentation
+    followup_comment:
+      label: Give details (optional)
+  -
+    label: Other property
+    value: Other property
+    followup_comment:
+      label: Give details (optional)
+validations:
+  -
+    type: required
+    message: Select the types of property

--- a/frameworks/person-escort-record/questions/property-bags.yml
+++ b/frameworks/person-escort-record/questions/property-bags.yml
@@ -1,0 +1,10 @@
+type: add_multiple_items
+question: Bags of property
+list_item_name: Bag
+questions:
+  - property-bag-seal-number
+  - property-bag-type
+validations:
+  -
+    type: required
+    message: Add at least one bag of property

--- a/frameworks/person-escort-record/questions/property-being-moved.yml
+++ b/frameworks/person-escort-record/questions/property-being-moved.yml
@@ -1,0 +1,15 @@
+type: radio
+question: Do they have any property to be moved?
+hint: For example, any medication, money, valuables, documentation or other valuables.
+description: Property being moved
+options:
+  -
+    label: "Yes"
+    value: "Yes"
+  -
+    label: "No"
+    value: "No"
+validations:
+  -
+    type: required
+    message: Select yes if the person has property to be moved

--- a/frameworks/person-escort-record/questions/property-being-retained.yml
+++ b/frameworks/person-escort-record/questions/property-being-retained.yml
@@ -1,0 +1,16 @@
+type: radio
+question: Is there any property being retained?
+description: Property retained
+options:
+  -
+    label: "Yes"
+    value: "Yes"
+    followup_comment:
+      label: Give details (optional)
+  -
+    label: "No"
+    value: "No"
+validations:
+  -
+    type: required
+    message: Select yes if the person has property being retained

--- a/frameworks/person-escort-record/questions/property-in-possession.yml
+++ b/frameworks/person-escort-record/questions/property-in-possession.yml
@@ -1,0 +1,21 @@
+type: radio
+question: Are they in possession of any property?
+hint: For example, jewellery
+description: In possession of property
+options:
+  -
+    label: "Yes"
+    value: "Yes"
+    followup_comment:
+      label: Give details
+      validations:
+        -
+          type: required
+          message: Enter details of any property in possession
+  -
+    label: "No"
+    value: "No"
+validations:
+  -
+    type: required
+    message: Select yes if the person has possession of any property


### PR DESCRIPTION
Add another or multiple type questions will require a new option for specifying the `item` name, the list of questions relating to an item and validations for the minimum/maximum number of items required.

Also add a display section to style text fields.