### PR TITLE
Add standard observation option for observation level question

### DIFF
--- a/frameworks/person-escort-record/questions/observation-level.yml
+++ b/frameworks/person-escort-record/questions/observation-level.yml
@@ -3,6 +3,9 @@ question: What is their current observation level?
 description: Current observation level
 options:
   -
+    label: Standard observation level — no additional observation required
+    value: Standard observation level — no additional observation required
+  -
     label: Check at least hourly
     value: Check at least hourly
   -


### PR DESCRIPTION
To accurately reflect the observation level of prisoners who are not a self harm risk and do not require observation