### PR TITLE
Add `nomis_fallback_mappings` property to questions

### DIFF
--- a/frameworks/person-escort-record/README.md
+++ b/frameworks/person-escort-record/README.md
@@ -88,6 +88,8 @@ Question files should live in [`questions/`](./questions) and be stored in a fla
 - `nomis_mappings` - list of NOMIS codes representing NOMIS alerts, personal care needs and reasonable adjustments mapped to a question, to display on questions.
   - `code` **(required)** - the code of the NOMIS resource
   - `type` **(required)** - the type of NOMIS resource. Current supported types for NOMIS mappings: `alert`, `personal_care_need` and `reasonable_adjustment`
+- `nomis_fallback_mappings` - list of NOMIS code types that will fallback to a question if they are not mapped to any other question.
+  - `type` **(required)** - the type of NOMIS resource. Current supported types for NOMIS mappings: `alert`, `personal_care_need` and `reasonable_adjustment`
 - `options` - for question types that require answers to be within a particular set of items. Usually for radios and checkboxes
   - `label` **(required)** - text displayed on the option label
   - `value` - value submitted to the server, defaults to value of `label`

--- a/frameworks/person-escort-record/questions/other-health-information.yml
+++ b/frameworks/person-escort-record/questions/other-health-information.yml
@@ -22,6 +22,11 @@ validations:
   -
     type: required
     message: Select yes if the person has any other information related to health
+nomis_fallback_mappings:
+  -
+    type: personal_care_need
+  -
+    type: reasonable_adjustment
 nomis_mappings:
   -
     code: OISFL # Incentivised Substance Free Living

--- a/frameworks/person-escort-record/questions/other-risk-information.yml
+++ b/frameworks/person-escort-record/questions/other-risk-information.yml
@@ -22,6 +22,9 @@ validations:
   -
     type: required
     message: Select yes if there is any other information related to risk you would like to include
+nomis_fallback_mappings:
+  -
+    type: alert
 nomis_mappings:
   -
     code: C1 # L1 Restriction No contact with any child


### PR DESCRIPTION
If a NOMIS resource is received, and is not mapped to any other question, it will fallback/be mapped to the specified question.
The new property defines to type of NOMIS resource to be mapped to the questions.