### PR TITLE
Add conditional validation on followup comments if NOMIS mappings present

### DIFF
--- a/frameworks/person-escort-record/README.md
+++ b/frameworks/person-escort-record/README.md
@@ -129,6 +129,7 @@ Validations are defined as an object containing a validation type (`type`) and a
 Supported validations:
 
 - `required` - mark a question as mandatory. For radios or checkboxes it will require at least one option to be selected, for text or textarea questions it will require at least 1 character, for add_multiple_items it will require at least 1 item.
+- `required_unless_nomis_mappings` - mark a text or textarea as mandatory, where it will require at least 1 character. If there are NOMIS mappings attached to the response, this will become optional. This validation only applies to the `followup_comment` option
 
 ## Markdown support
 

--- a/frameworks/person-escort-record/questions/actions-of-self-harm-undertaken.yml
+++ b/frameworks/person-escort-record/questions/actions-of-self-harm-undertaken.yml
@@ -10,7 +10,7 @@ options:
       label: Give details
       validations:
         -
-          type: required
+          type: required_unless_nomis_mappings
           message: Enter details of any cell sharing
   -
     label: Had a conversation with them
@@ -19,7 +19,7 @@ options:
       label: Give details
       validations:
         -
-          type: required
+          type: required_unless_nomis_mappings
           message: Enter details of any conversations
   -
     label: Placed them on an Assessment, Care in Custody and Teamwork (ACCT) plan
@@ -28,7 +28,7 @@ options:
       label: Give details
       validations:
         -
-          type: required
+          type: required_unless_nomis_mappings
           message: Enter details of any open Assessment, Care in Custody and Teamwork (ACCT) plans
     flags:
       -
@@ -41,7 +41,7 @@ options:
       label: Give details
       validations:
         -
-          type: required
+          type: required_unless_nomis_mappings
           message: Enter details of any medical professional referrals
   -
     label: Provided them with any additional support
@@ -51,7 +51,7 @@ options:
       label: Give details
       validations:
         -
-          type: required
+          type: required_unless_nomis_mappings
           message: Enter details of any additional support
   -
     label: Any other actions
@@ -60,7 +60,7 @@ options:
       label: Give details
       validations:
         -
-          type: required
+          type: required_unless_nomis_mappings
           message: Enter details of any other actions
   -
     label: No action taken

--- a/frameworks/person-escort-record/questions/addiction-dependencies.yml
+++ b/frameworks/person-escort-record/questions/addiction-dependencies.yml
@@ -10,7 +10,7 @@ options:
       label: Give details
       validations:
         -
-          type: required
+          type: required_unless_nomis_mappings
           message: Enter details of any addictions or dependencies that might affect them when they leave custody
     flags:
       -

--- a/frameworks/person-escort-record/questions/alcohol-withdrawal.yml
+++ b/frameworks/person-escort-record/questions/alcohol-withdrawal.yml
@@ -9,7 +9,7 @@ options:
       label: Give details
       validations:
         -
-          type: required
+          type: required_unless_nomis_mappings
           message: Enter any risk of alcohol withdrawal
     flags:
       -

--- a/frameworks/person-escort-record/questions/arsonist.yml
+++ b/frameworks/person-escort-record/questions/arsonist.yml
@@ -9,7 +9,7 @@ options:
       label: Give details
       validations:
         -
-          type: required
+          type: required_unless_nomis_mappings
           message: Enter details of why the person is an arsonist
     flags:
       -

--- a/frameworks/person-escort-record/questions/communication-needs.yml
+++ b/frameworks/person-escort-record/questions/communication-needs.yml
@@ -10,7 +10,7 @@ options:
       label: Give details
       validations:
         -
-          type: required
+          type: required_unless_nomis_mappings
           message: Enter communication needs
     flags:
       -

--- a/frameworks/person-escort-record/questions/current-or-previous-sex-offender.yml
+++ b/frameworks/person-escort-record/questions/current-or-previous-sex-offender.yml
@@ -10,7 +10,7 @@ options:
       label: Give details
       validations:
         -
-          type: required
+          type: required_unless_nomis_mappings
           message: Enter details of any current or previous sex offences
     flags:
       -

--- a/frameworks/person-escort-record/questions/escape-risk.yml
+++ b/frameworks/person-escort-record/questions/escape-risk.yml
@@ -10,7 +10,7 @@ options:
       label: Give details
       validations:
         -
-          type: required
+          type: required_unless_nomis_mappings
           message: Enter why the person is an escape risk
     flags:
       -

--- a/frameworks/person-escort-record/questions/gang-member-or-organised-crime.yml
+++ b/frameworks/person-escort-record/questions/gang-member-or-organised-crime.yml
@@ -9,7 +9,7 @@ options:
       label: Give details
       validations:
         -
-          type: required
+          type: required_unless_nomis_mappings
           message: Enter details of any involvements with gangs or organised crime
     flags:
       -

--- a/frameworks/person-escort-record/questions/help-with-personal-tasks.yml
+++ b/frameworks/person-escort-record/questions/help-with-personal-tasks.yml
@@ -10,7 +10,7 @@ options:
       label: Give details
       validations:
         -
-          type: required
+          type: required_unless_nomis_mappings
           message: Enter any help with personal tasks the person may need when they leave custody
     flags:
       -

--- a/frameworks/person-escort-record/questions/high-public-interest.yml
+++ b/frameworks/person-escort-record/questions/high-public-interest.yml
@@ -10,7 +10,7 @@ options:
       label: Give details
       validations:
         -
-          type: required
+          type: required_unless_nomis_mappings
           message: Enter why the person is of high public interest
     flags:
       -

--- a/frameworks/person-escort-record/questions/hostage-taker.yml
+++ b/frameworks/person-escort-record/questions/hostage-taker.yml
@@ -10,7 +10,7 @@ options:
       label: Give details
       validations:
         -
-          type: required
+          type: required_unless_nomis_mappings
           message: Enter details of why the person is a hostage taker
     flags:
       -

--- a/frameworks/person-escort-record/questions/mental-health-needs.yml
+++ b/frameworks/person-escort-record/questions/mental-health-needs.yml
@@ -10,7 +10,7 @@ options:
       label: Give details
       validations:
         -
-          type: required
+          type: required_unless_nomis_mappings
           message: Enter details of any mental health needs that might affect the person
     flags:
       -

--- a/frameworks/person-escort-record/questions/nature-of-self-harm.yml
+++ b/frameworks/person-escort-record/questions/nature-of-self-harm.yml
@@ -10,7 +10,7 @@ options:
       label: Give details
       validations:
         -
-          type: required
+          type: required_unless_nomis_mappings
           message: Enter details of any harm or attempted harm in custody
     flags:
       -
@@ -23,7 +23,7 @@ options:
       label: Give details
       validations:
         -
-          type: required
+          type: required_unless_nomis_mappings
           message: Enter details of anything the person has said about self-harm or suicide
     flags:
       -
@@ -36,7 +36,7 @@ options:
       label: Give details
       validations:
         -
-          type: required
+          type: required_unless_nomis_mappings
           message: Enter details of anything someone else has said about self-harm or suicide
     flags:
       -
@@ -49,7 +49,7 @@ options:
       label: Give details
       validations:
         -
-          type: required
+          type: required_unless_nomis_mappings
           message: Enter details of signs of behavioural mental disorder
     flags:
       -
@@ -62,7 +62,7 @@ options:
       label: Give details
       validations:
         -
-          type: required
+          type: required_unless_nomis_mappings
           message: Enter details of any reactions
     flags:
       -
@@ -75,7 +75,7 @@ options:
       label: Give details
       validations:
         -
-          type: required
+          type: required_unless_nomis_mappings
           message: Enter details of a Pre-Sentence Report
     flags:
       -
@@ -88,7 +88,7 @@ options:
       label: Give details
       validations:
         -
-          type: required
+          type: required_unless_nomis_mappings
           message: Enter details of any other concerns
     flags:
       -

--- a/frameworks/person-escort-record/questions/other-health-information.yml
+++ b/frameworks/person-escort-record/questions/other-health-information.yml
@@ -9,7 +9,7 @@ options:
       label: Give details
       validations:
         -
-          type: required
+          type: required_unless_nomis_mappings
           message: Enter any other information related to health you would like to include
     flags:
       -

--- a/frameworks/person-escort-record/questions/other-risk-information.yml
+++ b/frameworks/person-escort-record/questions/other-risk-information.yml
@@ -9,7 +9,7 @@ options:
       label: Give details
       validations:
         -
-          type: required
+          type: required_unless_nomis_mappings
           message: Enter any other information related to risk you would like to include
     flags:
       -

--- a/frameworks/person-escort-record/questions/physical-health-needs.yml
+++ b/frameworks/person-escort-record/questions/physical-health-needs.yml
@@ -10,7 +10,7 @@ options:
       label: Give details
       validations:
         -
-          type: required
+          type: required_unless_nomis_mappings
           message: Enter any physical health needs that might affect the person
     flags:
       -

--- a/frameworks/person-escort-record/questions/pregnant.yml
+++ b/frameworks/person-escort-record/questions/pregnant.yml
@@ -9,7 +9,7 @@ options:
       label: Give details
       validations:
         -
-          type: required
+          type: required_unless_nomis_mappings
           message: Enter details of pregnancy
     flags:
       -

--- a/frameworks/person-escort-record/questions/release-status.yml
+++ b/frameworks/person-escort-record/questions/release-status.yml
@@ -10,7 +10,7 @@ options:
       label: Give details
       validations:
         -
-          type: required
+          type: required_unless_nomis_mappings
           message: Enter details of why this person should not be released
     flags:
       -

--- a/frameworks/person-escort-record/questions/requires-special-vehicle.yml
+++ b/frameworks/person-escort-record/questions/requires-special-vehicle.yml
@@ -10,7 +10,7 @@ options:
       label: Give details
       validations:
         -
-          type: required
+          type: required_unless_nomis_mappings
           message: Enter details of any special vehicle requirements
     flags:
       -

--- a/frameworks/person-escort-record/questions/risk-from-other-people.yml
+++ b/frameworks/person-escort-record/questions/risk-from-other-people.yml
@@ -10,7 +10,7 @@ options:
       label: Give details
       validations:
         -
-          type: required
+          type: required_unless_nomis_mappings
           message: Enter why the person is at risk from other people
     flags:
       -

--- a/frameworks/person-escort-record/questions/risk-to-other-people.yml
+++ b/frameworks/person-escort-record/questions/risk-to-other-people.yml
@@ -10,7 +10,7 @@ options:
       label: Give details
       validations:
         -
-          type: required
+          type: required_unless_nomis_mappings
           message: Enter details of why the person is a risk to staff
     flags:
       -
@@ -23,7 +23,7 @@ options:
       label: Give details
       validations:
         -
-          type: required
+          type: required_unless_nomis_mappings
           message: Enter details of why the person is a risk to females
     flags:
       -
@@ -36,7 +36,7 @@ options:
       label: Give details
       validations:
         -
-          type: required
+          type: required_unless_nomis_mappings
           message: Enter details of why the person is a risk to lesbian, gay or bisexual people
     flags:
       -
@@ -49,7 +49,7 @@ options:
       label: Give details
       validations:
         -
-          type: required
+          type: required_unless_nomis_mappings
           message: Enter details of why the person is a risk to transgender or transexual people
     flags:
       -
@@ -62,7 +62,7 @@ options:
       label: Give details
       validations:
         -
-          type: required
+          type: required_unless_nomis_mappings
           message: Enter details of why the person is a risk to other races
     flags:
       -
@@ -75,7 +75,7 @@ options:
       label: Give details
       validations:
         -
-          type: required
+          type: required_unless_nomis_mappings
           message: Enter details of why the person is a risk to other religions
     flags:
       -
@@ -88,7 +88,7 @@ options:
       label: Give details
       validations:
         -
-          type: required
+          type: required_unless_nomis_mappings
           message: Enter details of why the person is a risk to any other group
     flags:
       -

--- a/frameworks/person-escort-record/questions/stalker-harasser-or-intimidator.yml
+++ b/frameworks/person-escort-record/questions/stalker-harasser-or-intimidator.yml
@@ -10,7 +10,7 @@ options:
       label: Give details
       validations:
         -
-          type: required
+          type: required_unless_nomis_mappings
           message: Enter details of a stalking, harassment or intimidation
     flags:
       -

--- a/frameworks/person-escort-record/questions/terrorism-offences.yml
+++ b/frameworks/person-escort-record/questions/terrorism-offences.yml
@@ -10,7 +10,7 @@ options:
       label: Give details
       validations:
         -
-          type: required
+          type: required_unless_nomis_mappings
           message: Enter details of any terrorism offences
     flags:
       -

--- a/frameworks/person-escort-record/questions/violent-or-dangerous.yml
+++ b/frameworks/person-escort-record/questions/violent-or-dangerous.yml
@@ -10,7 +10,7 @@ options:
       label: Give details
       validations:
         -
-          type: required
+          type: required_unless_nomis_mappings
           message: Enter why the person is violent or dangerous
     flags:
       -

--- a/frameworks/person-escort-record/questions/wheelchair-user.yml
+++ b/frameworks/person-escort-record/questions/wheelchair-user.yml
@@ -9,7 +9,7 @@ options:
       label: Give details
       validations:
         -
-          type: required
+          type: required_unless_nomis_mappings
           message: Enter details of any wheelchair use
     flags:
       -


### PR DESCRIPTION
* Add a new `required_unless_nomis_mappings` validation only on followup comments, which requires a comment unless there are NOMIS mappings attached to the response. 
* Amend all validations on followup comments to optional if NOMIS mappings attached to question
