### PR TITLE
P4-2352 Add prefill option to questions.

### DIFF
--- a/frameworks/person-escort-record/README.md
+++ b/frameworks/person-escort-record/README.md
@@ -90,7 +90,7 @@ Question files should live in [`questions/`](./questions) and be stored in a fla
   - `type` **(required)** - the type of NOMIS resource. Current supported types for NOMIS mappings: `alert`, `personal_care_need` and `reasonable_adjustment`
 - `nomis_fallback_mappings` - list of NOMIS code types that will fallback to a question if they are not mapped to any other question.
   - `type` **(required)** - the type of NOMIS resource. Current supported types for NOMIS mappings: `alert`, `personal_care_need` and `reasonable_adjustment`
-- `prefill` - boolean marker to indicate if a question response should be pre-filled by a previous person escort record matching response if available. Accepted values are `true` or `false`
+- `prefill` - indicates if a question's response should be populated by the previously completed Person Escort Record. If there is no previous record or the question does not exist in the previous record the response will be left empty. Accepted values are `true` or `false`.
 - `options` - for question types that require answers to be within a particular set of items. Usually for radios and checkboxes
   - `label` **(required)** - text displayed on the option label
   - `value` - value submitted to the server, defaults to value of `label`

--- a/frameworks/person-escort-record/README.md
+++ b/frameworks/person-escort-record/README.md
@@ -90,6 +90,7 @@ Question files should live in [`questions/`](./questions) and be stored in a fla
   - `type` **(required)** - the type of NOMIS resource. Current supported types for NOMIS mappings: `alert`, `personal_care_need` and `reasonable_adjustment`
 - `nomis_fallback_mappings` - list of NOMIS code types that will fallback to a question if they are not mapped to any other question.
   - `type` **(required)** - the type of NOMIS resource. Current supported types for NOMIS mappings: `alert`, `personal_care_need` and `reasonable_adjustment`
+- `prefill` - boolean marker to indicate if a question response should be pre-filled by a previous person escort record matching response if available. Accepted values are `true` or `false`
 - `options` - for question types that require answers to be within a particular set of items. Usually for radios and checkboxes
   - `label` **(required)** - text displayed on the option label
   - `value` - value submitted to the server, defaults to value of `label`

--- a/frameworks/person-escort-record/questions/actions-of-self-harm-undertaken.yml
+++ b/frameworks/person-escort-record/questions/actions-of-self-harm-undertaken.yml
@@ -2,6 +2,7 @@ type: checkbox
 question: What actions have been taken to keep this person safe?
 hint: Select all that apply
 description: Actions taken to keep person safe
+prefill: true
 options:
   -
     label: Placed them in a cell with others

--- a/frameworks/person-escort-record/questions/addiction-dependencies.yml
+++ b/frameworks/person-escort-record/questions/addiction-dependencies.yml
@@ -2,6 +2,7 @@ type: radio
 question: Do they have any addictions or dependencies that might affect them when they leave custody?
 hint: For example, substance misuse
 description: Addictions or dependencies
+prefill: true
 options:
   -
     label: "Yes"

--- a/frameworks/person-escort-record/questions/alcohol-withdrawal.yml
+++ b/frameworks/person-escort-record/questions/alcohol-withdrawal.yml
@@ -1,6 +1,7 @@
 type: radio
 question: Are they experiencing or at risk of alcohol withdrawal?
 description: Alcohol withdrawal
+prefill: true
 options:
   -
     label: "Yes"

--- a/frameworks/person-escort-record/questions/arsonist.yml
+++ b/frameworks/person-escort-record/questions/arsonist.yml
@@ -1,6 +1,7 @@
 type: radio
 question: Are they an arsonist?
 description: Arsonist
+prefill: true
 options:
   -
     label: "Yes"

--- a/frameworks/person-escort-record/questions/child-date-of-birth.yml
+++ b/frameworks/person-escort-record/questions/child-date-of-birth.yml
@@ -1,6 +1,7 @@
 type: text
 question: Child’s date of birth
 hint: For example 28/10/2019 or 28 October 2019
+prefill: false
 validations:
   -
     type: required

--- a/frameworks/person-escort-record/questions/child-full-name.yml
+++ b/frameworks/person-escort-record/questions/child-full-name.yml
@@ -1,5 +1,6 @@
 type: text
 question: Child’s full name
+prefill: false
 validations:
   -
     type: required

--- a/frameworks/person-escort-record/questions/communication-needs.yml
+++ b/frameworks/person-escort-record/questions/communication-needs.yml
@@ -2,6 +2,7 @@ type: radio
 question: Do they have any communication needs?
 hint: For example, any foreign language or literacy needs, including visual or hearing impairments
 description: Communication needs
+prefill: true
 options:
   -
     label: "Yes"

--- a/frameworks/person-escort-record/questions/concealed-items.yml
+++ b/frameworks/person-escort-record/questions/concealed-items.yml
@@ -2,6 +2,7 @@ type: checkbox
 question: What restricted items have they concealed, created or used?
 hint: Select all that apply
 description: Items concealed, created or used
+prefill: true
 options:
   -
     label: Created or used weapons

--- a/frameworks/person-escort-record/questions/current-offences.yml
+++ b/frameworks/person-escort-record/questions/current-offences.yml
@@ -2,6 +2,7 @@ type: textarea
 question: What offences were they charged with?
 hint: Include the offence names and any custody or occurrence reference numbers
 description: Current offences
+prefill: true
 validations:
   -
     type: required

--- a/frameworks/person-escort-record/questions/current-or-previous-sex-offender.yml
+++ b/frameworks/person-escort-record/questions/current-or-previous-sex-offender.yml
@@ -2,6 +2,7 @@ type: radio
 question: Are they a current or previous sex offender?
 hint: This doesn’t include prostitution offences, except where the charge is the procurement of others into prostitution
 description: Sex offender
+prefill: true
 options:
   -
     label: "Yes"

--- a/frameworks/person-escort-record/questions/escape-risk.yml
+++ b/frameworks/person-escort-record/questions/escape-risk.yml
@@ -2,6 +2,7 @@ type: radio
 question: Are they an escape risk?
 hint: For example, they are on the Escape (‘E’) list or there is relevant information about escape attempts
 description: Escape risk
+prefill: true
 options:
   -
     label: "Yes"

--- a/frameworks/person-escort-record/questions/female-hygiene-kit.yml
+++ b/frameworks/person-escort-record/questions/female-hygiene-kit.yml
@@ -1,6 +1,7 @@
 type: radio
 question: Do they need a female hygiene kit?
 description: Requires female hygiene kit
+prefill: true
 options:
   -
     label: "Yes"

--- a/frameworks/person-escort-record/questions/gang-member-or-organised-crime.yml
+++ b/frameworks/person-escort-record/questions/gang-member-or-organised-crime.yml
@@ -1,6 +1,7 @@
 type: radio
 question: Are they a gang member or involved in organised crime?
 description: Gang member or involved in organised crime
+prefill: true
 options:
   -
     label: "Yes"

--- a/frameworks/person-escort-record/questions/has-concealed-items.yml
+++ b/frameworks/person-escort-record/questions/has-concealed-items.yml
@@ -2,6 +2,7 @@ type: radio
 question: Have they concealed, created or used any restricted items in custody?
 hint: For example, weapons, drugs, mobile phones or SIM cards
 description: Concealed, created or used restricted items
+prefill: true
 options:
   -
     label: "Yes"

--- a/frameworks/person-escort-record/questions/health-contact-details.yml
+++ b/frameworks/person-escort-record/questions/health-contact-details.yml
@@ -2,6 +2,7 @@ type: radio
 question: Is there a contact number for someone who can provide more information about the person’s health information?
 hint: For example, a medical professional who has up-to-date health details
 description: Custody contact number for health
+prefill: false
 options:
   -
     label: "Yes"

--- a/frameworks/person-escort-record/questions/health-issues.yml
+++ b/frameworks/person-escort-record/questions/health-issues.yml
@@ -1,6 +1,7 @@
 type: radio
 question: Do they have any physical or mental health issues?
 description: Health issues
+prefill: true
 options:
   -
     label: "Yes"

--- a/frameworks/person-escort-record/questions/held-separately.yml
+++ b/frameworks/person-escort-record/questions/held-separately.yml
@@ -2,6 +2,7 @@ type: radio
 question: Should this person be held separately?
 hint: For example, they are at risk of physical or verbal abuse from others, or are discriminatory towards others, including prison, police, escort, court or medical staff
 description: Hold separately
+prefill: true
 options:
   -
     label: "Yes"

--- a/frameworks/person-escort-record/questions/help-with-personal-tasks.yml
+++ b/frameworks/person-escort-record/questions/help-with-personal-tasks.yml
@@ -2,6 +2,7 @@ type: radio
 question: Will they need help with personal tasks when they leave custody?
 hint: For example, going to the toilet, eating or drinking
 description: Help with personal tasks
+prefill: true
 options:
   -
     label: "Yes"

--- a/frameworks/person-escort-record/questions/high-public-interest.yml
+++ b/frameworks/person-escort-record/questions/high-public-interest.yml
@@ -2,6 +2,7 @@ type: radio
 question: Are they of high public interest?
 hint: For example, if they are a public figure or involved in a high profile case
 description: Of high public interest
+prefill: true
 options:
   -
     label: "Yes"

--- a/frameworks/person-escort-record/questions/history-of-self-harm-details.yml
+++ b/frameworks/person-escort-record/questions/history-of-self-harm-details.yml
@@ -1,6 +1,7 @@
 type: textarea
 question: Give details
 description: Self-harm history details
+prefill: true
 validations:
   -
     type: required

--- a/frameworks/person-escort-record/questions/history-of-self-harm-method.yml
+++ b/frameworks/person-escort-record/questions/history-of-self-harm-method.yml
@@ -2,6 +2,7 @@ type: checkbox
 question: What methods were used to self-harm?
 hint: Select all that apply
 description: Methods used to self-harm
+prefill: true
 options:
   -
     label: Ligature

--- a/frameworks/person-escort-record/questions/history-of-self-harm-recency.yml
+++ b/frameworks/person-escort-record/questions/history-of-self-harm-recency.yml
@@ -1,6 +1,7 @@
 type: radio
 question: How recently did self-harm occur?
 description: Recency of self-harm
+prefill: false
 options:
   -
     label: Within the last month

--- a/frameworks/person-escort-record/questions/history-of-self-harm.yml
+++ b/frameworks/person-escort-record/questions/history-of-self-harm.yml
@@ -1,6 +1,7 @@
 type: radio
 question: Is there a history of self-harm?
 description: History of self-harm
+prefill: true
 options:
   -
     label: "Yes"

--- a/frameworks/person-escort-record/questions/hostage-taker.yml
+++ b/frameworks/person-escort-record/questions/hostage-taker.yml
@@ -2,6 +2,7 @@ type: radio
 question: Are they a hostage taker?
 hint: Including threatened hostage situations
 description: Hostage taker
+prefill: true
 options:
   -
     label: "Yes"

--- a/frameworks/person-escort-record/questions/indication-of-self-harm-or-suicide.yml
+++ b/frameworks/person-escort-record/questions/indication-of-self-harm-or-suicide.yml
@@ -1,5 +1,6 @@
 type: radio
 question: Is there any indication that they might self-harm or attempt suicide?
+prefill: true
 hint: |
   For example, the person:
 

--- a/frameworks/person-escort-record/questions/medical-health-professional-referral.yml
+++ b/frameworks/person-escort-record/questions/medical-health-professional-referral.yml
@@ -1,6 +1,7 @@
 type: radio
 question: Have they been referred to a medical professional, including a Liaison and Diversion professional?
 description: Referred to a medical professional
+prefill: false
 options:
   -
     label: "Yes"

--- a/frameworks/person-escort-record/questions/medication-carrier-while-moving.yml
+++ b/frameworks/person-escort-record/questions/medication-carrier-while-moving.yml
@@ -1,6 +1,7 @@
 type: radio
 question: Who will carry the medication?
 description: Medication carrier while moving
+prefill: true
 options:
   -
     label: Escort

--- a/frameworks/person-escort-record/questions/medication-while-moving-details.yml
+++ b/frameworks/person-escort-record/questions/medication-while-moving-details.yml
@@ -1,5 +1,6 @@
 type: textarea
 question: Provide details of medication required while moving
+prefill: true
 hint: |
   Include the following details:
 

--- a/frameworks/person-escort-record/questions/medication-while-moving.yml
+++ b/frameworks/person-escort-record/questions/medication-while-moving.yml
@@ -1,6 +1,7 @@
 type: radio
 question: Do they need to take any medication while moving?
 description: Medication while moving
+prefill: true
 options:
   -
     label: "Yes"

--- a/frameworks/person-escort-record/questions/mental-health-needs.yml
+++ b/frameworks/person-escort-record/questions/mental-health-needs.yml
@@ -2,6 +2,7 @@ type: radio
 question: Do they have mental health needs?
 hint: For example, there is a relevant mental health or self-harm risk
 description: Mental health needs
+prefill: true
 options:
   -
     label: "Yes"

--- a/frameworks/person-escort-record/questions/nature-of-self-harm.yml
+++ b/frameworks/person-escort-record/questions/nature-of-self-harm.yml
@@ -2,6 +2,7 @@ type: checkbox
 question: What is the nature of the self-harm concern?
 hint: Select all that apply
 description: Nature of self-harm
+prefill: true
 options:
   -
     label: They have harmed or attempted to harm themself in custody

--- a/frameworks/person-escort-record/questions/observation-level.yml
+++ b/frameworks/person-escort-record/questions/observation-level.yml
@@ -1,6 +1,7 @@
 type: radio
 question: What is their current observation level?
 description: Current observation level
+prefill: false
 options:
   -
     label: Standard observation level — no additional observation required

--- a/frameworks/person-escort-record/questions/other-health-information.yml
+++ b/frameworks/person-escort-record/questions/other-health-information.yml
@@ -1,6 +1,7 @@
 type: radio
 question: Is there any other information related to health you would like to include?
 description: Other health information
+prefill: true
 options:
   -
     label: "Yes"

--- a/frameworks/person-escort-record/questions/other-risk-information.yml
+++ b/frameworks/person-escort-record/questions/other-risk-information.yml
@@ -1,6 +1,7 @@
 type: radio
 question: Is there any other information related to risk you would like to include?
 description: Other risk information
+prefill: true
 options:
   -
     label: "Yes"

--- a/frameworks/person-escort-record/questions/physical-health-needs.yml
+++ b/frameworks/person-escort-record/questions/physical-health-needs.yml
@@ -2,6 +2,7 @@ type: radio
 question: Do they have any physical health needs?
 hint: For example, an illness or infection that may require treatment, or they may not be able to be handcuffed or have breathing difficulties. Also consider any mobility concerns, such as crutches or walking sticks.
 description: Physical health needs
+prefill: true
 options:
   -
     label: "Yes"

--- a/frameworks/person-escort-record/questions/pregnant.yml
+++ b/frameworks/person-escort-record/questions/pregnant.yml
@@ -1,6 +1,7 @@
 type: radio
 question: Have they said that they are pregnant?
 description: Pregnant
+prefill: true
 options:
   -
     label: "Yes"

--- a/frameworks/person-escort-record/questions/prescribed-medication-carrier.yml
+++ b/frameworks/person-escort-record/questions/prescribed-medication-carrier.yml
@@ -1,6 +1,7 @@
 type: radio
 question: Who will carry the medication?
 description: Prescribed medication carrier
+prefill: true
 options:
   -
     label: Escort

--- a/frameworks/person-escort-record/questions/prescribed-medication-details.yml
+++ b/frameworks/person-escort-record/questions/prescribed-medication-details.yml
@@ -1,5 +1,6 @@
 type: textarea
 question: Provide details of medication
+prefill: true
 hint: |
   Include the following details:
 

--- a/frameworks/person-escort-record/questions/prescribed-medication.yml
+++ b/frameworks/person-escort-record/questions/prescribed-medication.yml
@@ -2,6 +2,7 @@ type: radio
 question: Do they need or have they been prescribed any other medication not required while moving?
 hint: This includes relevant regular medication that they need or already have with them, as well as anything that they may have been prescribed whilst in custody
 description: Prescribed medication
+prefill: true
 options:
   -
     label: "Yes"

--- a/frameworks/person-escort-record/questions/property-bag-seal-number.yml
+++ b/frameworks/person-escort-record/questions/property-bag-seal-number.yml
@@ -1,5 +1,6 @@
 type: text
 question: Seal number
+prefill: false
 display:
   character_width: 20
 validations:

--- a/frameworks/person-escort-record/questions/property-bag-type.yml
+++ b/frameworks/person-escort-record/questions/property-bag-type.yml
@@ -2,6 +2,7 @@ type: checkbox
 question: What type of property is in the bag?
 hint: Select all that apply
 description: Contents
+prefill: false
 options:
   -
     label: Medication

--- a/frameworks/person-escort-record/questions/property-being-moved.yml
+++ b/frameworks/person-escort-record/questions/property-being-moved.yml
@@ -2,6 +2,7 @@ type: radio
 question: Do they have any property to be moved?
 hint: For example, any medication, money, valuables, documentation or other valuables.
 description: Property being moved
+prefill: false
 options:
   -
     label: "Yes"

--- a/frameworks/person-escort-record/questions/property-being-retained.yml
+++ b/frameworks/person-escort-record/questions/property-being-retained.yml
@@ -1,6 +1,7 @@
 type: radio
 question: Is there any property being retained?
 description: Property retained
+prefill: false
 options:
   -
     label: "Yes"

--- a/frameworks/person-escort-record/questions/property-in-possession.yml
+++ b/frameworks/person-escort-record/questions/property-in-possession.yml
@@ -2,6 +2,7 @@ type: radio
 question: Are they in possession of any property?
 hint: For example, jewellery
 description: In possession of property
+prefill: false
 options:
   -
     label: "Yes"

--- a/frameworks/person-escort-record/questions/release-status.yml
+++ b/frameworks/person-escort-record/questions/release-status.yml
@@ -2,6 +2,7 @@ type: radio
 question: Is there a reason this person should not be released?
 hint: For example, they may be wanted by immigration or recalled to custody
 description: Release status
+prefill: true
 options:
   -
     label: "Yes, this person should not be released"

--- a/frameworks/person-escort-record/questions/requires-special-vehicle.yml
+++ b/frameworks/person-escort-record/questions/requires-special-vehicle.yml
@@ -2,6 +2,7 @@ type: radio
 question: Is there a reason why this person might need to travel in a special vehicle?
 hint: This could be a specially-adapted prison van (for example, to accommodate wheelchairs)
 description: May require special vehicle
+prefill: true
 options:
   -
     label: "Yes"

--- a/frameworks/person-escort-record/questions/risk-from-other-people.yml
+++ b/frameworks/person-escort-record/questions/risk-from-other-people.yml
@@ -2,6 +2,7 @@ type: radio
 question: Are they at risk of physical or verbal abuse from other people?
 hint: Check for any recent vulnerable or at risk alerts or intel
 description: Vulnerable — at risk from other people
+prefill: true
 options:
   -
     label: "Yes"

--- a/frameworks/person-escort-record/questions/risk-to-other-people.yml
+++ b/frameworks/person-escort-record/questions/risk-to-other-people.yml
@@ -2,6 +2,7 @@ type: checkbox
 question: Are they a risk to specific groups?
 hint: Select any that apply
 description: Risk to other people
+prefill: true
 options:
   -
     label: Staff

--- a/frameworks/person-escort-record/questions/sensitive-medication.yml
+++ b/frameworks/person-escort-record/questions/sensitive-medication.yml
@@ -2,6 +2,7 @@ type: radio
 question: Does this person have any sensitive medical or medication information that needs to be shared with health staff at the receiving location?
 hint: This will be provided to the escort in a sealed envelope during handover
 description: Sensitive medical information
+prefill: false
 options:
   -
     label: "Yes"

--- a/frameworks/person-escort-record/questions/special-diet-or-allergies.yml
+++ b/frameworks/person-escort-record/questions/special-diet-or-allergies.yml
@@ -2,6 +2,7 @@ type: radio
 question: Do they have any known special diet or allergies?
 hint: For example, dietary, medical or environmental allergies
 description: Special diet or allergies
+prefill: true
 options:
   -
     label: "Yes"

--- a/frameworks/person-escort-record/questions/stalker-harasser-or-intimidator.yml
+++ b/frameworks/person-escort-record/questions/stalker-harasser-or-intimidator.yml
@@ -2,6 +2,7 @@ type: radio
 question: Are they a stalker, harasser or intimidator?
 hint: For example, they have a Restraining Order or a Civil Injunction against them or intel suggests that they may attempt to harass or intimidate witnesses, co-defendants or others. Staff should consider who this person can call.
 description: Stalker, harasser or intimidator
+prefill: true
 options:
   -
     label: "Yes"

--- a/frameworks/person-escort-record/questions/terrorism-offences.yml
+++ b/frameworks/person-escort-record/questions/terrorism-offences.yml
@@ -2,6 +2,7 @@ type: radio
 question: Have they committed any current or previous offences connected to terrorism?
 description: Terrorism related offences
 hint: This includes any terrorism offences, as well as any offences with a connection to terrorism
+prefill: true
 options:
   -
     label: "Yes"

--- a/frameworks/person-escort-record/questions/travelling-with-child.yml
+++ b/frameworks/person-escort-record/questions/travelling-with-child.yml
@@ -1,6 +1,7 @@
 type: radio
 question: Are they travelling with a child?
 description: Travelling with a child
+prefill: false
 options:
   -
     label: "Yes"

--- a/frameworks/person-escort-record/questions/violent-or-dangerous.yml
+++ b/frameworks/person-escort-record/questions/violent-or-dangerous.yml
@@ -2,6 +2,7 @@ type: radio
 question: Are they violent or dangerous?
 hint: For example, is there any relevant history of violence, actual or threatened
 description: Violent or dangerous
+prefill: true
 options:
   -
     label: "Yes"

--- a/frameworks/person-escort-record/questions/wheelchair-user.yml
+++ b/frameworks/person-escort-record/questions/wheelchair-user.yml
@@ -1,6 +1,7 @@
 type: radio
 question: Are they a wheelchair user?
 description: Wheelchair user
+prefill: true
 options:
   -
     label: "Yes"


### PR DESCRIPTION
jira-ticket: https://dsdmoj.atlassian.net/browse/P4-2352

A question's response can be prefilled from a previous PER on creation if a matching question and response are available.
Mark all questions to either be prefilled true/false by a previous PER.