### PR TITLE
Change general info flags type to information

### DIFF
--- a/frameworks/youth-risk-assessment/questions/first-language.yml
+++ b/frameworks/youth-risk-assessment/questions/first-language.yml
@@ -19,7 +19,7 @@ options:
     flags:
       -
         label: English not first language
-        type: attention
+        type: information
 validations:
   -
     type: required

--- a/frameworks/youth-risk-assessment/questions/negative-impact-on-behaviour.yml
+++ b/frameworks/youth-risk-assessment/questions/negative-impact-on-behaviour.yml
@@ -16,7 +16,7 @@ options:
     flags:
       -
         label: Behaviour triggers
-        type: alert
+        type: information
   -
     label: "No"
     value: "No"

--- a/frameworks/youth-risk-assessment/questions/religious-or-cultural-needs.yml
+++ b/frameworks/youth-risk-assessment/questions/religious-or-cultural-needs.yml
@@ -16,7 +16,7 @@ options:
     flags:
       -
         label: Religious or cultural needs
-        type: attention
+        type: information
   -
     label: "No"
     value: "No"


### PR DESCRIPTION
General info flags type should be information which renders as a grey flag on the FE, rather than alert (red) or attention (blue)