### PR TITLE
Add full stops to the end of hint texts

### DIFF
--- a/frameworks/person-escort-record/questions/actions-of-self-harm-undertaken.yml
+++ b/frameworks/person-escort-record/questions/actions-of-self-harm-undertaken.yml
@@ -1,6 +1,6 @@
 type: checkbox
 question: What actions have been taken to keep this person safe?
-hint: Select all that apply
+hint: Select all that apply.
 description: Actions taken to keep person safe
 prefill: true
 options:
@@ -46,7 +46,7 @@ options:
           message: Enter details of any medical professional referrals
   -
     label: Provided them with any additional support
-    hint: For example, a call to family or the Samaritans
+    hint: For example, a call to family or the Samaritans.
     value: Provided them with any additional support
     followup_comment:
       label: Give details

--- a/frameworks/person-escort-record/questions/addiction-dependencies.yml
+++ b/frameworks/person-escort-record/questions/addiction-dependencies.yml
@@ -1,6 +1,6 @@
 type: radio
 question: Do they have any addictions or dependencies that might affect them when they leave custody?
-hint: For example, substance misuse
+hint: For example, substance misuse.
 description: Addictions or dependencies
 prefill: true
 options:

--- a/frameworks/person-escort-record/questions/child-date-of-birth.yml
+++ b/frameworks/person-escort-record/questions/child-date-of-birth.yml
@@ -1,6 +1,6 @@
 type: text
 question: Child’s date of birth
-hint: For example 28/10/2019 or 28 October 2019
+hint: For example 28/10/2019 or 28 October 2019.
 prefill: false
 validations:
   -

--- a/frameworks/person-escort-record/questions/communication-needs.yml
+++ b/frameworks/person-escort-record/questions/communication-needs.yml
@@ -1,6 +1,6 @@
 type: radio
 question: Do they have any communication needs?
-hint: For example, any foreign language or literacy needs, including visual or hearing impairments
+hint: For example, any foreign language or literacy needs, including visual or hearing impairments.
 description: Communication needs
 prefill: true
 options:

--- a/frameworks/person-escort-record/questions/concealed-items.yml
+++ b/frameworks/person-escort-record/questions/concealed-items.yml
@@ -1,6 +1,6 @@
 type: checkbox
 question: What restricted items have they concealed, created or used?
-hint: Select all that apply
+hint: Select all that apply.
 description: Items concealed, created or used
 prefill: true
 options:

--- a/frameworks/person-escort-record/questions/current-offences.yml
+++ b/frameworks/person-escort-record/questions/current-offences.yml
@@ -1,6 +1,6 @@
 type: textarea
 question: What offences were they charged with?
-hint: Include the offence names and any custody or occurrence reference numbers
+hint: Include the offence names and any custody or occurrence reference numbers.
 description: Current offences
 prefill: true
 validations:

--- a/frameworks/person-escort-record/questions/current-or-previous-sex-offender.yml
+++ b/frameworks/person-escort-record/questions/current-or-previous-sex-offender.yml
@@ -1,6 +1,6 @@
 type: radio
 question: Are they a current or previous sex offender?
-hint: This doesn’t include prostitution offences, except where the charge is the procurement of others into prostitution
+hint: This doesn’t include prostitution offences, except where the charge is the procurement of others into prostitution.
 description: Sex offender
 prefill: true
 options:

--- a/frameworks/person-escort-record/questions/escape-risk.yml
+++ b/frameworks/person-escort-record/questions/escape-risk.yml
@@ -1,6 +1,6 @@
 type: radio
 question: Are they an escape risk?
-hint: For example, they are on the Escape (‘E’) list or there is relevant information about escape attempts
+hint: For example, they are on the Escape (‘E’) list or there is relevant information about escape attempts.
 description: Escape risk
 prefill: true
 options:

--- a/frameworks/person-escort-record/questions/has-concealed-items.yml
+++ b/frameworks/person-escort-record/questions/has-concealed-items.yml
@@ -1,6 +1,6 @@
 type: radio
 question: Have they concealed, created or used any restricted items in custody?
-hint: For example, weapons, drugs, mobile phones or SIM cards
+hint: For example, weapons, drugs, mobile phones or SIM cards.
 description: Concealed, created or used restricted items
 prefill: true
 options:

--- a/frameworks/person-escort-record/questions/health-contact-details.yml
+++ b/frameworks/person-escort-record/questions/health-contact-details.yml
@@ -1,6 +1,6 @@
 type: radio
 question: Is there a contact number for someone who can provide more information about the person’s health information?
-hint: For example, a medical professional who has up-to-date health details
+hint: For example, a medical professional who has up-to-date health details.
 description: Custody contact number for health
 prefill: false
 options:

--- a/frameworks/person-escort-record/questions/held-separately.yml
+++ b/frameworks/person-escort-record/questions/held-separately.yml
@@ -1,6 +1,6 @@
 type: radio
 question: Should this person be held separately?
-hint: For example, they are at risk of physical or verbal abuse from others, or are discriminatory towards others, including prison, police, escort, court or medical staff
+hint: For example, they are at risk of physical or verbal abuse from others, or are discriminatory towards others, including prison, police, escort, court or medical staff.
 description: Hold separately
 prefill: true
 options:

--- a/frameworks/person-escort-record/questions/help-with-personal-tasks.yml
+++ b/frameworks/person-escort-record/questions/help-with-personal-tasks.yml
@@ -1,6 +1,6 @@
 type: radio
 question: Will they need help with personal tasks when they leave custody?
-hint: For example, going to the toilet, eating or drinking
+hint: For example, going to the toilet, eating or drinking.
 description: Help with personal tasks
 prefill: true
 options:

--- a/frameworks/person-escort-record/questions/high-public-interest.yml
+++ b/frameworks/person-escort-record/questions/high-public-interest.yml
@@ -1,6 +1,6 @@
 type: radio
 question: Are they of high public interest?
-hint: For example, if they are a public figure or involved in a high profile case
+hint: For example, if they are a public figure or involved in a high profile case.
 description: Of high public interest
 prefill: true
 options:

--- a/frameworks/person-escort-record/questions/history-of-self-harm-method.yml
+++ b/frameworks/person-escort-record/questions/history-of-self-harm-method.yml
@@ -1,12 +1,12 @@
 type: checkbox
 question: What methods were used to self-harm?
-hint: Select all that apply
+hint: Select all that apply.
 description: Methods used to self-harm
 prefill: true
 options:
   -
     label: Ligature
-    hint: For example, a cord, rope, or other material, for hanging or strangulation
+    hint: For example, a cord, rope, or other material, for hanging or strangulation.
     value: Ligature
   -
     label: Cutting

--- a/frameworks/person-escort-record/questions/history-of-self-harm-recency.yml
+++ b/frameworks/person-escort-record/questions/history-of-self-harm-recency.yml
@@ -1,6 +1,6 @@
 type: text
 question: Date when the last incident took place
-hint: For example 28/10/2019 or 28 October 2019
+hint: For example 28/10/2019 or 28 October 2019.
 prefill: true
 display:
   character_width: 10

--- a/frameworks/person-escort-record/questions/hostage-taker.yml
+++ b/frameworks/person-escort-record/questions/hostage-taker.yml
@@ -1,6 +1,6 @@
 type: radio
 question: Are they a hostage taker?
-hint: Including threatened hostage situations
+hint: Including threatened hostage situations.
 description: Hostage taker
 prefill: true
 options:

--- a/frameworks/person-escort-record/questions/medication-details.yml
+++ b/frameworks/person-escort-record/questions/medication-details.yml
@@ -1,6 +1,6 @@
 type: add_multiple_items
 question: Provide medication details
-hint: Provide information about any medication they have taken within the last 72 hours (including painkillers) or any regular medication they take or may need during the move or once transferred (including long-term moves and time spent at additional locations)
+hint: Provide information about any medication they have taken within the last 72 hours (including painkillers) or any regular medication they take or may need during the move or once transferred (including long-term moves and time spent at additional locations).
 list_item_name: Medication
 questions:
   - medication-name

--- a/frameworks/person-escort-record/questions/mental-health-needs.yml
+++ b/frameworks/person-escort-record/questions/mental-health-needs.yml
@@ -1,6 +1,6 @@
 type: radio
 question: Do they have mental health needs?
-hint: For example, there is a relevant mental health or self-harm risk
+hint: For example, there is a relevant mental health or self-harm risk.
 description: Mental health needs
 prefill: true
 options:

--- a/frameworks/person-escort-record/questions/nature-of-self-harm.yml
+++ b/frameworks/person-escort-record/questions/nature-of-self-harm.yml
@@ -1,6 +1,6 @@
 type: checkbox
 question: What is the nature of the self-harm concern?
-hint: Select all that apply
+hint: Select all that apply.
 description: Nature of self-harm
 prefill: true
 options:

--- a/frameworks/person-escort-record/questions/prescribed-medication.yml
+++ b/frameworks/person-escort-record/questions/prescribed-medication.yml
@@ -1,6 +1,6 @@
 type: radio
 question: Do they need or have they been prescribed any medication?
-hint: This consists of any medication they have taken within the last 72 hours (including painkillers) or any regular medication they take or may need during the move or once transferred (including long-term moves and time spent at additional locations)
+hint: This consists of any medication they have taken within the last 72 hours (including painkillers) or any regular medication they take or may need during the move or once transferred (including long-term moves and time spent at additional locations).
 description: Prescribed medication
 prefill: true
 options:

--- a/frameworks/person-escort-record/questions/property-bag-type.yml
+++ b/frameworks/person-escort-record/questions/property-bag-type.yml
@@ -1,6 +1,6 @@
 type: checkbox
 question: What type of property is in the bag?
-hint: Select all that apply
+hint: Select all that apply.
 description: Contents
 prefill: false
 options:
@@ -15,7 +15,7 @@ options:
     followup_comment:
       type: text
       label: Total amount, in pounds
-      hint: For example, 23.99
+      hint: For example, 23.99.
       display:
         character_width: 5
         prefix: £

--- a/frameworks/person-escort-record/questions/property-in-possession.yml
+++ b/frameworks/person-escort-record/questions/property-in-possession.yml
@@ -1,6 +1,6 @@
 type: radio
 question: Are they in possession of any property?
-hint: For example, jewellery
+hint: For example, jewellery.
 description: In possession of property
 prefill: false
 options:

--- a/frameworks/person-escort-record/questions/release-status.yml
+++ b/frameworks/person-escort-record/questions/release-status.yml
@@ -1,6 +1,6 @@
 type: radio
 question: Is there a reason this person should not be released?
-hint: For example, they may be wanted by immigration or recalled to custody
+hint: For example, they may be wanted by immigration or recalled to custody.
 description: Release status
 prefill: true
 options:

--- a/frameworks/person-escort-record/questions/requires-special-vehicle.yml
+++ b/frameworks/person-escort-record/questions/requires-special-vehicle.yml
@@ -1,6 +1,6 @@
 type: radio
 question: Is there a reason why this person might need to travel in a special vehicle?
-hint: This could be a specially-adapted prison van (for example, to accommodate wheelchairs)
+hint: This could be a specially-adapted prison van (for example, to accommodate wheelchairs).
 description: May require special vehicle
 prefill: true
 options:

--- a/frameworks/person-escort-record/questions/risk-from-other-people.yml
+++ b/frameworks/person-escort-record/questions/risk-from-other-people.yml
@@ -1,6 +1,6 @@
 type: radio
 question: Are they at risk of physical or verbal abuse from other people?
-hint: Check for any recent vulnerable or at risk alerts or intel
+hint: Check for any recent vulnerable or at risk alerts or intel.
 description: Vulnerable — at risk from other people
 prefill: true
 options:

--- a/frameworks/person-escort-record/questions/risk-to-other-people.yml
+++ b/frameworks/person-escort-record/questions/risk-to-other-people.yml
@@ -1,6 +1,6 @@
 type: checkbox
 question: Are they a risk to specific groups?
-hint: Select any that apply
+hint: Select any that apply.
 description: Risk to other people
 prefill: true
 options:

--- a/frameworks/person-escort-record/questions/sensitive-medication.yml
+++ b/frameworks/person-escort-record/questions/sensitive-medication.yml
@@ -1,6 +1,6 @@
 type: radio
 question: Does this person have any sensitive medical or medication information that needs to be shared with health staff at the receiving location?
-hint: This will be provided to the escort in a sealed envelope during handover
+hint: This will be provided to the escort in a sealed envelope during handover.
 description: Sensitive medical information
 prefill: true
 options:

--- a/frameworks/person-escort-record/questions/special-diet-or-allergies.yml
+++ b/frameworks/person-escort-record/questions/special-diet-or-allergies.yml
@@ -1,6 +1,6 @@
 type: radio
 question: Do they have any known special diet or allergies?
-hint: For example, dietary, medical or environmental allergies
+hint: For example, dietary, medical or environmental allergies.
 description: Special diet or allergies
 prefill: true
 options:

--- a/frameworks/person-escort-record/questions/terrorism-offences.yml
+++ b/frameworks/person-escort-record/questions/terrorism-offences.yml
@@ -1,7 +1,7 @@
 type: radio
 question: Have they committed any current or previous offences connected to terrorism?
 description: Terrorism related offences
-hint: This includes any terrorism offences, as well as any offences with a connection to terrorism
+hint: This includes any terrorism offences, as well as any offences with a connection to terrorism.
 prefill: true
 options:
   -

--- a/frameworks/person-escort-record/questions/violent-or-dangerous.yml
+++ b/frameworks/person-escort-record/questions/violent-or-dangerous.yml
@@ -1,6 +1,6 @@
 type: radio
 question: Are they violent or dangerous?
-hint: For example, is there any relevant history of violence, actual or threatened
+hint: For example, is there any relevant history of violence, actual or threatened.
 description: Violent or dangerous
 prefill: true
 options:

--- a/frameworks/youth-risk-assessment/questions/first-time-in-custody-date.yml
+++ b/frameworks/youth-risk-assessment/questions/first-time-in-custody-date.yml
@@ -1,6 +1,6 @@
 type: text
 question: Date of their first time in custody at any establishment
-hint: For example 28/10/2019 or 28 October 2019
+hint: For example 28/10/2019 or 28 October 2019.
 prefill: true
 display:
   character_width: 10

--- a/frameworks/youth-risk-assessment/questions/health-affecting-transport.yml
+++ b/frameworks/youth-risk-assessment/questions/health-affecting-transport.yml
@@ -1,7 +1,7 @@
 type: checkbox
 question: Do they have any health issues that may affect transport?
 description: Health affecting transport
-hint: Select any that apply
+hint: Select any that apply.
 prefill: true
 options:
   -

--- a/frameworks/youth-risk-assessment/questions/risks-with-moving.yml
+++ b/frameworks/youth-risk-assessment/questions/risks-with-moving.yml
@@ -1,7 +1,7 @@
 type: checkbox
 question: Are there any risks with moving them?
 description: Risks with moving
-hint: Select any that apply
+hint: Select any that apply.
 prefill: true
 options:
   -


### PR DESCRIPTION
At the moment we're inconsistent with the use of a full stop at the end of hint texts. We could either remove them all and rely on the frontend to add them, or put them all in here explicitly. We've decided to go with the latter to avoid unnecessary extra logic in the frontend and make it more flexible.

[Jira Ticket](https://dsdmoj.atlassian.net/browse/P4-2991)