### PR TITLE
Revert "Bump to version 2.2.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "@hmpps-book-secure-move-frameworks/2.1.0",
-  "version": "2.2.0",
+  "version": "2.1.0",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@hmpps-book-secure-move-frameworks/2.2.0",
-  "version": "2.2.0",
+  "name": "@hmpps-book-secure-move-frameworks/2.1.0",
+  "version": "2.1.0",
   "description": "YAML definitions for the frameworks used by the Book a secure move service",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Reverts ministryofjustice/hmpps-book-secure-move-frameworks#54

We actually want to wait on this release to include the Cell Sharing Risk Assessment changes!