### PR TITLE
Add CSRA NOMIS mapping to "Should this person be held separately?"

### DIFF
--- a/frameworks/person-escort-record/questions/held-separately.yml
+++ b/frameworks/person-escort-record/questions/held-separately.yml
@@ -106,3 +106,5 @@ nomis_mappings:
     type: alert
   - code: XSA  # Staff Assaulter
     type: alert
+  - code: CSR  # Cell Share Risk Assessment
+    type: assessment


### PR DESCRIPTION
This adds a new NOMIS mapping to the "Should this person be held separately?" question for displaying the Cell Share Risk Assessment information on the frontend.

Depends on https://github.com/ministryofjustice/hmpps-book-secure-move-api/pull/1500 which has now been merged.

[Jira Ticket](https://dsdmoj.atlassian.net/browse/P4-2860)